### PR TITLE
Integrate AI subagents and chat UI badges

### DIFF
--- a/netlify/functions/ai-sdk.ts
+++ b/netlify/functions/ai-sdk.ts
@@ -1,0 +1,65 @@
+type AISDKConfig = {
+  apiKey?: string;
+  baseURL?: string;
+};
+
+type ChatMessage = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+type GenerateTextOptions = {
+  model: string;
+  messages: ChatMessage[];
+  temperature?: number;
+  topP?: number;
+  maxTokens?: number;
+};
+
+type GenerateTextResult = {
+  text: string;
+  raw: unknown;
+};
+
+export type AISDKClient = {
+  generateText: (options: GenerateTextOptions) => Promise<GenerateTextResult>;
+};
+
+export const createAISDK = ({ apiKey, baseURL }: AISDKConfig): AISDKClient => {
+  const resolvedBaseURL = (baseURL ?? 'https://models.inference.ai.azure.com').replace(/\/$/, '');
+
+  const generateText = async ({
+    model,
+    messages,
+    temperature,
+    topP,
+    maxTokens,
+  }: GenerateTextOptions): Promise<GenerateTextResult> => {
+    const response = await fetch(`${resolvedBaseURL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature,
+        top_p: topP,
+        max_tokens: maxTokens,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`AI SDK error: ${response.status} ${response.statusText} - ${errorText}`);
+    }
+
+    const data = await response.json();
+    const text = data?.choices?.[0]?.message?.content ?? '';
+
+    return { text, raw: data };
+  };
+
+  return { generateText };
+};

--- a/netlify/functions/ai-subagents.ts
+++ b/netlify/functions/ai-subagents.ts
@@ -1,0 +1,48 @@
+export type SubagentId = "general" | "projects" | "blog" | "experience" | "hiring";
+
+type SubagentConfig = {
+  id: SubagentId;
+  label: string;
+  systemPrompt: string;
+  routerHint: string;
+};
+
+export const subagents: Record<SubagentId, SubagentConfig> = {
+  general: {
+    id: "general",
+    label: "General Assistant",
+    routerHint: "General questions, greetings, and broad requests.",
+    systemPrompt:
+      "You are the general assistant. Provide helpful, polished answers and keep the tone professional.",
+  },
+  projects: {
+    id: "projects",
+    label: "Projects & Tech",
+    routerHint: "Questions about projects, architecture, stacks, or technical implementation.",
+    systemPrompt:
+      "You are the projects-focused subagent. Emphasize technical architecture, stack choices, and implementation details.",
+  },
+  blog: {
+    id: "blog",
+    label: "Blog Guide",
+    routerHint: "Questions about blog posts, summaries, or editorial content.",
+    systemPrompt:
+      "You are the blog-focused subagent. Summarize and explain blog content clearly, then offer key takeaways.",
+  },
+  experience: {
+    id: "experience",
+    label: "Experience & Background",
+    routerHint: "Questions about professional experience, roles, responsibilities, or impact.",
+    systemPrompt:
+      "You are the experience-focused subagent. Highlight roles, responsibilities, and outcomes.",
+  },
+  hiring: {
+    id: "hiring",
+    label: "Hiring & Collaboration",
+    routerHint: "Questions about availability, collaboration, or hiring fit.",
+    systemPrompt:
+      "You are the hiring-focused subagent. Emphasize collaboration style, strengths, and fit.",
+  },
+};
+
+export const subagentIds = Object.keys(subagents) as SubagentId[];

--- a/netlify/functions/chat.ts
+++ b/netlify/functions/chat.ts
@@ -1,19 +1,70 @@
 import { Handler } from '@netlify/functions';
+import { createAISDK } from './ai-sdk';
+import { subagents, subagentIds, SubagentId } from './ai-subagents';
+
+type ChatRequest = {
+  messages: Array<{
+    role: 'user' | 'assistant' | 'system';
+    content: string;
+  }>;
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  model?: string;
+};
+
+const aiClient = createAISDK({
+  apiKey: process.env.API_TOKEN,
+  baseURL: process.env.AI_BASE_URL ?? 'https://models.inference.ai.azure.com',
+});
+
+const normalizeSubagent = (value: string): SubagentId => {
+  const cleaned = value.toLowerCase().replace(/[^a-z]/g, '');
+  const match = subagentIds.find((id) => cleaned.includes(id));
+  return match ?? 'general';
+};
+
+const selectSubagent = async (message: string): Promise<SubagentId> => {
+  const routerPrompt = `You are a routing assistant for subagents.
+Choose the best subagent for the user message and respond with only one id from this list:
+${subagentIds.join(', ')}.
+
+Subagent hints:
+${subagentIds
+  .map((id) => `- ${id}: ${subagents[id].routerHint}`)
+  .join('\n')}`;
+
+  const { text } = await aiClient.generateText({
+    model: 'gpt-4o-mini',
+    temperature: 0,
+    maxTokens: 32,
+    messages: [
+      {
+        role: 'system',
+        content: routerPrompt,
+      },
+      {
+        role: 'user',
+        content: message || 'General inquiry',
+      },
+    ],
+  });
+
+  return normalizeSubagent(text.trim());
+};
 
 export const handler: Handler = async (event) => {
-  // Enable CORS
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Content-Type': 'application/json'
+    'Content-Type': 'application/json',
   };
 
-  // Handle preflight requests
   if (event.httpMethod === 'OPTIONS') {
     return {
       statusCode: 200,
-      headers
+      headers,
     };
   }
 
@@ -22,35 +73,69 @@ export const handler: Handler = async (event) => {
       throw new Error('No request body');
     }
 
-    console.log('API Token:', process.env.API_TOKEN ? 'exists' : 'missing');
-    console.log('Request Body:', event.body);
+    const request = JSON.parse(event.body) as ChatRequest;
+    const { messages, temperature = 0.7, top_p = 0.9, max_tokens = 4000 } = request;
+    const modelName = request.model ?? 'gpt-4o-mini';
 
-    const response = await fetch('https://models.inference.ai.azure.com/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.API_TOKEN}`
-      },
-      body: event.body
+    if (!messages?.length) {
+      throw new Error('No messages provided');
+    }
+
+    const lastUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+    const routedSubagent = await selectSubagent(lastUserMessage?.content ?? '');
+    const subagentConfig = subagents[routedSubagent];
+
+    const baseSystemMessages = messages.filter((message) => message.role === 'system');
+    const baseSystem = baseSystemMessages.map((message) => message.content).join('\n\n');
+    const combinedSystem = [baseSystem, subagentConfig.systemPrompt].filter(Boolean).join('\n\n');
+
+    const chatMessages = messages
+      .filter((message) => message.role !== 'system')
+      .map((message) => ({
+        role: message.role,
+        content: message.content,
+      }));
+
+    const { text } = await aiClient.generateText({
+      model: modelName,
+      temperature,
+      topP: top_p,
+      maxTokens: max_tokens,
+      messages: [
+        {
+          role: 'system',
+          content: combinedSystem,
+        },
+        ...chatMessages,
+      ],
     });
-
-    const data = await response.json();
-    console.log('API Response:', data);
 
     return {
       statusCode: 200,
       headers,
-      body: JSON.stringify(data)
+      body: JSON.stringify({
+        choices: [
+          {
+            message: {
+              content: text,
+            },
+          },
+        ],
+        agent: {
+          id: subagentConfig.id,
+          label: subagentConfig.label,
+        },
+      }),
     };
   } catch (error) {
     console.error('Error:', error);
     return {
       statusCode: 500,
       headers,
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         error: error instanceof Error ? error.message : 'Unknown error occurred',
-        details: error instanceof Error ? error.stack : undefined
-      })
+        details: error instanceof Error ? error.stack : undefined,
+      }),
     };
   }
-}; 
+};

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -3,6 +3,7 @@ import { X, Trash2, Maximize2, Minimize2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import { Message, ChatBoxProps, BlogContext } from '../types/types';
 import { AIInput } from './ui/ai-input';
+import { AIMessageBubble, AIMessagePanel, AIMessageShell, AIAgentBadge } from './ui/ai-elements';
 import { createEnhancedSystemPrompt } from '../prompts/system-prompt-loader'; 
 
 
@@ -52,7 +53,11 @@ export default function ChatBox({ isOpen, onClose, isDarkMode = true, initialMes
     if (!blogContext) {
       setMessages([{
         role: 'assistant',
-        content: "Hi! I'm Ethan's AI assistant. Feel free to ask me about his experience, projects, or skills in software development, AI solutions, and project management."
+        content: "Hi! I'm Ethan's AI assistant. Feel free to ask me about his experience, projects, or skills in software development, AI solutions, and project management.",
+        agent: {
+          id: 'general',
+          label: 'General Assistant'
+        }
       }]);
       setCurrentBlogContext(undefined);
       hasProcessedInitialMessage.current = null;
@@ -139,7 +144,8 @@ When asked to summarize or discuss this blog, provide helpful insights based on 
 
       const assistantMessage: Message = {
         role: 'assistant' as const,
-        content: data.choices[0].message.content
+        content: data.choices[0].message.content,
+        agent: data.agent ?? undefined
       };
       
       setMessages(prev => [...prev, assistantMessage]);
@@ -247,7 +253,11 @@ When asked to summarize or discuss this blog, provide helpful insights based on 
       role: 'assistant',
       content: currentBlogContext 
         ? `Chat cleared. I still have context about the blog "${currentBlogContext.title}". Feel free to ask more questions about it or anything else!`
-        : "Hi! I'm Ethan's AI assistant. Feel free to ask me about his experience, projects, or skills in software development, AI solutions, and project management."
+        : "Hi! I'm Ethan's AI assistant. Feel free to ask me about his experience, projects, or skills in software development, AI solutions, and project management.",
+      agent: {
+        id: 'general',
+        label: 'General Assistant'
+      }
     }]);
   };
 
@@ -307,22 +317,23 @@ When asked to summarize or discuss this blog, provide helpful insights based on 
             </div>
           )}
           {messages.map((message, index) => (
-            <div
+            <AIMessageShell
               key={index}
-              className={`flex ${
-                message.role === 'user' ? 'justify-end' : 'justify-start'
-              }`}
+              role={message.role === 'user' ? 'user' : 'assistant'}
             >
               {message.role === 'user' ? (
-                <div className="max-w-[85%] rounded-2xl px-4 py-3 bg-gray-800/80 text-white text-sm">
+                <AIMessageBubble>
                   {renderMessage(message)}
-                </div>
+                </AIMessageBubble>
               ) : (
-                <div className={`${isFullscreen ? 'max-w-[90%]' : 'w-full'}`}>
+                <AIMessagePanel className={`${isFullscreen ? 'max-w-[90%]' : 'w-full'}`}>
+                  {message.agent?.label && (
+                    <AIAgentBadge label={message.agent.label} />
+                  )}
                   {renderMessage(message)}
-                </div>
+                </AIMessagePanel>
               )}
-            </div>
+            </AIMessageShell>
           ))}
           {isLoading && (
             <div className="flex justify-start">

--- a/src/components/ui/ai-elements.tsx
+++ b/src/components/ui/ai-elements.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+type AIMessageShellProps = {
+  role: "user" | "assistant";
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function AIMessageShell({ role, className, children }: AIMessageShellProps) {
+  return (
+    <div
+      className={cn(
+        "flex w-full",
+        role === "user" ? "justify-end" : "justify-start",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type AIMessageBubbleProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function AIMessageBubble({ className, children }: AIMessageBubbleProps) {
+  return (
+    <div
+      className={cn(
+        "max-w-[85%] rounded-2xl px-4 py-3 text-sm",
+        "bg-gray-800/80 text-white shadow-sm",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type AIMessagePanelProps = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function AIMessagePanel({ className, children }: AIMessagePanelProps) {
+  return (
+    <div className={cn("space-y-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+type AIAgentBadgeProps = {
+  label: string;
+  className?: string;
+};
+
+export function AIAgentBadge({ label, className }: AIAgentBadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border border-gray-700/70",
+        "bg-gray-900/70 px-2.5 py-1 text-xs font-medium text-gray-200",
+        className
+      )}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-orange-400" />
+      {label}
+    </span>
+  );
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,6 +1,10 @@
 export type Message = {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  agent?: {
+    id: string;
+    label: string;
+  };
 };
 
 export type BlogContext = {


### PR DESCRIPTION
### Motivation
- Introduce a small AI SDK and subagent routing so the chat function can pick focused assistant personas for different user intents.
- Surface which subagent responded via the UI so users see contextual agent badges and clearer responses.
- Encapsulate AI calls and routing logic server-side to keep frontend integration simple and extensible.

### Description
- Add `netlify/functions/ai-sdk.ts` as a lightweight internal AI client with a `generateText` helper to call the configured models endpoint.  
- Add `netlify/functions/ai-subagents.ts` to declare subagent ids, labels, hints, and system prompts used for routing.  
- Replace the Netlify chat handler (`netlify/functions/chat.ts`) to route the last user message to a selected subagent, combine subagent system prompts with existing system context, call the AI SDK, and return `agent` metadata with responses.  
- Add UI components in `src/components/ui/ai-elements.tsx`, extend `Message` with optional `agent` metadata in `src/types/types.ts`, and update `src/components/ChatBox.tsx` to render message shells/panels/bubbles and display an `AIAgentBadge` when agent info is present, plus set a default greeting agent.

### Testing
- Launched the dev server with `pnpm dev` and verified the app served locally (Vite started successfully).  
- Ran Playwright scripts that loaded the page and exercised the Chat button, producing screenshots (`page-home.png` and `ai-chat-badge.png`) which show the chat UI and the agent badge (artifacts produced).  
- An initial `pnpm install` attempt failed due to a private/forbidden npm package (403) and the transient dependency attempt was reverted, after which the internal SDK approach was used; no failing runtime regressions were observed in the local dev session.  
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698623f308c48330a34688be68e72d95)