### PR TITLE
Add Juice to portfolio projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ dist/index.html
 
 #convex generated files
 convex\_generated
+
+# .lavish
+.lavish/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ Thumbs.db
 
 # Local Netlify folder
 .netlify
+/.pnpm-store/
 dist/assets/index-DBCbKdaL.js
 dist/index.html
 

--- a/src/components/MinimalView.tsx
+++ b/src/components/MinimalView.tsx
@@ -132,10 +132,7 @@ function ProjectItem({ project, showLink }: { project: Project; showLink?: boole
   return (
     <div className="flex flex-col gap-1">
       <div className="flex flex-wrap items-baseline justify-between gap-x-3">
-        <h3 className="text-white font-semibold">
-          {project.name}
-          <span className="ml-2 text-gray-600 text-xs font-mono font-normal">{project.tech}</span>
-        </h3>
+        <h3 className="text-white font-semibold">{project.name}</h3>
         {showLink && project.liveUrl && <ExternalLink href={project.liveUrl}>Visit</ExternalLink>}
       </div>
       <p className="text-gray-400 text-sm leading-relaxed">{project.description}</p>

--- a/src/components/MinimalView.tsx
+++ b/src/components/MinimalView.tsx
@@ -129,11 +129,13 @@ function ExternalLink({ href, children }: { href: string; children: React.ReactN
 }
 
 function ProjectItem({ project, showLink }: { project: Project; showLink?: boolean }) {
+  const projectUrl = project.liveUrl ?? project.linkUrl;
+
   return (
     <div className="flex flex-col gap-1">
       <div className="flex flex-wrap items-baseline justify-between gap-x-3">
         <h3 className="text-white font-semibold">{project.name}</h3>
-        {showLink && project.liveUrl && <ExternalLink href={project.liveUrl}>Visit</ExternalLink>}
+        {showLink && projectUrl && <ExternalLink href={projectUrl}>Visit</ExternalLink>}
       </div>
       <p className="text-gray-400 text-sm leading-relaxed">{project.description}</p>
       <div className="mt-1 flex flex-wrap gap-1.5">

--- a/src/components/MinimalView.tsx
+++ b/src/components/MinimalView.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { MapPin, Mail, ArrowUpRight, GraduationCap, Github, Linkedin, Twitter } from 'lucide-react';
+import { MapPin, Mail, ArrowUpRight, GraduationCap, Github, Linkedin } from 'lucide-react';
+import { SiX } from 'react-icons/si';
 import { SYSTEM_CONTEXT } from '../types/types';
 import { projects as featuredProjects, type Project } from '../data/projects';
 import profileImage from '../assets/profile.jpg';
@@ -25,7 +26,7 @@ const PROFILE_LINKS = [
   { label: 'Email', href: 'mailto:ethan@clinick.net', Icon: Mail },
   { label: 'LinkedIn', href: context.linkedin, Icon: Linkedin },
   { label: 'GitHub', href: 'https://github.com/eclinick', Icon: Github },
-  { label: 'X', href: 'https://x.com/EthanClinick', Icon: Twitter },
+  { label: 'X', href: 'https://x.com/EthanClinick', Icon: SiX },
 ];
 
 const MONTHS: Record<string, number> = {
@@ -187,10 +188,11 @@ export default function MinimalView() {
                 href={href}
                 target={href.startsWith('mailto:') ? undefined : '_blank'}
                 rel="noopener noreferrer"
+                aria-label={label}
                 className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-gray-300 hover:bg-white/10 hover:text-white transition-colors"
               >
                 <Icon className="w-3.5 h-3.5" />
-                {label}
+                {label !== 'X' && label}
               </a>
             ))}
           </div>

--- a/src/components/featured-projects.tsx
+++ b/src/components/featured-projects.tsx
@@ -233,6 +233,16 @@ export default function FeaturedProjects() {
                     <p className="text-gray-400 text-lg leading-relaxed max-w-4xl">
                       {currentProject.description}
                     </p>
+                    {currentProject.linkUrl && (
+                      <a
+                        href={currentProject.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex text-sm font-medium text-orange-400 transition-colors hover:text-orange-300"
+                      >
+                        View project ↗
+                      </a>
+                    )}
                   </div>
 
                   {/* Navigation Dots */}
@@ -327,6 +337,16 @@ export default function FeaturedProjects() {
                     <p className="text-gray-400 text-sm leading-relaxed">
                       {project.description}
                     </p>
+                    {project.linkUrl && (
+                      <a
+                        href={project.linkUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex text-sm font-medium text-orange-400 transition-colors hover:text-orange-300"
+                      >
+                        View project ↗
+                      </a>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -11,6 +11,7 @@ export interface Project {
   image: string
   tags: string[]
   liveUrl?: string
+  linkUrl?: string
   retired?: boolean
   mockupContent: {
     title: string
@@ -24,6 +25,21 @@ export interface Project {
  * FeaturedProjects section and the condensed Résumé view so the two never drift.
  */
 export const projects: Project[] = [
+  {
+    id: 5,
+    name: "Juice",
+    tech: "Swift 6 + SwiftUI",
+    description: "A privacy-first macOS menu-bar app that reveals the apps draining your battery, with per-app watt-hour history, charge timelines, and plain-English energy insights.",
+    color: "from-lime-500 via-emerald-600 to-green-800",
+    image: "https://raw.githubusercontent.com/EClinick/juice/main/docs/images/popover.png",
+    tags: ["macOS", "SwiftUI", "Battery Analytics"],
+    linkUrl: "https://github.com/EClinick/juice",
+    mockupContent: {
+      title: "Juice",
+      subtitle: "Battery analytics from macOS power data",
+      interface: "analytics",
+    },
+  },
   {
     id: 1,
     name: "TradeMind",

--- a/src/prompts/SYSTEM_PROMPT.MD
+++ b/src/prompts/SYSTEM_PROMPT.MD
@@ -88,6 +88,7 @@ If users seem unsure what to ask, suggest topics like:
 - "How does Ethan approach building scalable backend systems?"
 - "What's Ethan's experience with startup founding and leadership?"
 - "Can you explain the technical architecture behind Tan.ai or PlanGenie?"
+- "How does Juice surface per-app battery usage while preserving macOS security boundaries?"
 - "What's Ethan's approach to integrating AI into business solutions?"
 
 ## Limitations & Boundaries

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -88,6 +88,20 @@ export const SYSTEM_CONTEXT = {
       ],
       projects: [
         {
+          name: "Juice",
+          description: "A privacy-first macOS menu-bar app that makes the system's per-app energy accounting useful, showing what is draining the battery and how usage changes over time.",
+          technologies: ["Swift 6", "SwiftUI", "XPC", "SQLite", "macOS"],
+          features: [
+            "Live battery percentage and charging or draw wattage in the menu bar",
+            "Per-app energy rankings for today, three days, or a week, with CPU, GPU, and Neural Engine breakdowns",
+            "Local charge timelines, long-term rollups, and personalized energy-use insights",
+            "A development privileged helper that reads macOS powerlog data through XPC; a Team ID-pinned release trust model is planned",
+            "Fully local operation with no network access, telemetry, or accounts"
+          ],
+          githubUrl: "https://github.com/EClinick/juice",
+          status: "Early development"
+        },
+        {
           name: "Crypto Mining Monitor Bot",
           description: "A comprehensive Discord bot for monitoring cryptocurrency mining operations",
           technologies: ["Python", "Discord.py", "Docker", "API Integration"],
@@ -120,7 +134,7 @@ export const SYSTEM_CONTEXT = {
           ]
         }
       ],
-      
+
       skills: [
         "Python (2022)", 
         "Rust (2023)", 
@@ -151,4 +165,3 @@ export const SYSTEM_CONTEXT = {
       ]
     }
   };
-  


### PR DESCRIPTION
## Summary
- add Juice, a privacy-first macOS battery-analytics app, to the featured project data
- surface Juice’s GitHub repository from the featured and résumé project views
- extend the portfolio assistant context with accurate Juice architecture, privacy, and development-security details
- ignore the local pnpm package-store cache

## Validation
- `pnpm exec tsc -b --pretty false`
- `pnpm run build`
- `pnpm run lint`
- iterative Terra review (all findings resolved)